### PR TITLE
Prevent system from including additional scenes in a limapp when building

### DIFF
--- a/SDK/Editor/Builder/AppBuilder.cs
+++ b/SDK/Editor/Builder/AppBuilder.cs
@@ -95,6 +95,15 @@ namespace Liminal.SDK.Editor.Build
             if (buildInfo == null)
                 throw new ArgumentNullException("buildInfo");
 
+            // boolean true forces the asset bundles to be deleted even if they're in use.
+            var assetBundles = AssetDatabase.GetAllAssetBundleNames();
+            foreach (var bundle in assetBundles)
+            {
+                AssetDatabase.RemoveAssetBundleName(bundle, true);
+            }
+
+            AssetImporter.GetAtPath(buildInfo.Scene.path).SetAssetBundleNameAndVariant("appscene", "");
+
             // Get and verify the target platform is supported
             var appPlatform = MapAppTargetPlatform(buildInfo.BuildTarget);
             if (appPlatform == AppPackPlatform.Unknown)

--- a/SDK/Editor/Builder/AppBuilder.cs
+++ b/SDK/Editor/Builder/AppBuilder.cs
@@ -95,10 +95,10 @@ namespace Liminal.SDK.Editor.Build
             if (buildInfo == null)
                 throw new ArgumentNullException("buildInfo");
 
-            // boolean true forces the asset bundles to be deleted even if they're in use.
             var assetBundles = AssetDatabase.GetAllAssetBundleNames();
             foreach (var bundle in assetBundles)
             {
+                // boolean true forces the asset bundles to be deleted even if they're in use.
                 AssetDatabase.RemoveAssetBundleName(bundle, true);
             }
 


### PR DESCRIPTION
Adds code to force delete all asset bundles (even if they're in use) and then sets the target scene's asset bundle to 'appscene'. This prevents multiple scenes from being built to a single limapp and also stops non-scene assets from breaking the app builder script if they're accidentally set to an asset bundle.